### PR TITLE
fixing bad flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Flags:
   -a, --source-token string          Source Organization GitHub token. Scopes: read:org, read:user, user:email
   -t, --target-organization string   Target Organization to sync teams from
   -b, --target-token string          Target Organization GitHub token. Scopes: admin:org
-  -u, --user-sync string             User sync mode. One of: all, disable (default "none")
+  -z, --user-sync string             User sync mode. One of: all, disable (default "none")
 ```
 
 ### Mapping File Example

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -68,6 +68,6 @@ func init() {
 
 	syncCmd.Flags().StringP("source-hostname", "u", "", "GitHub Enterprise source hostname url (optional) Ex. https://github.example.com")
 
-	syncCmd.Flags().StringP("user-sync", "u", "all", "User sync mode. One of: all, disable (default \"none\")")
+	syncCmd.Flags().StringP("user-sync", "z", "all", "User sync mode. One of: all, disable (default \"none\")")
 
 }


### PR DESCRIPTION
# Fixing Bad Flag

Turns out `-u` was already taken moving `user-sync` to `-z`.