### PR TITLE
fix release to go version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b #v4.1.4
       - uses: cli/gh-extension-precompile@v1
         with:
-          go_version: 1.19.x
+          go_version: 1.21


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow file `.github/workflows/release.yml`. The changes involve updating the version of the `actions/checkout` action and the Go language version used in the `gh-extension-precompile` action.