### PR TITLE
feat: migrate team member role too

### DIFF
--- a/internal/team/team.go
+++ b/internal/team/team.go
@@ -25,6 +25,7 @@ type Team struct {
 type Member struct {
 	Login string
 	Email string
+	Role  string
 }
 
 type Repository struct {
@@ -67,6 +68,7 @@ func getTeamMemberships(team string) []Member {
 		members = append(members, Member{
 			Login: member["Login"],
 			Email: member["Email"],
+			Role:  member["Role"],
 		})
 	}
 
@@ -113,7 +115,7 @@ func (t Team) CreateTeam() {
 
 	if userSync != "disable" {
 		for _, member := range t.Members {
-			api.AddTeamMember(t.Slug, member.Login)
+			api.AddTeamMember(t.Slug, member.Login, member.Role)
 		}
 	}
 }


### PR DESCRIPTION
The changes include the addition of a `Role` field to the `Member` struct and the `GetTeamMemberships` function, modifications to the `AddTeamMember` function to include the member's role, and updates to the `CreateTeam` function to utilize the member's role when adding team members.

Also fixes a bug introduced in #12 , where the `CreateTeam` API may get stuck if the ParentTeamID was not found.