### PR TITLE
adds skip teams flag to byRepos cmd

### DIFF
--- a/cmd/byRepos.go
+++ b/cmd/byRepos.go
@@ -29,6 +29,7 @@ var byReposCmd = &cobra.Command{
 		mappingFile := cmd.Flag("mapping-file").Value.String()
 		ghHostname := cmd.Flag("source-hostname").Value.String()
 		repoFile := cmd.Flag("from-file").Value.String()
+		skipTeams := cmd.Flag("skip-teams").Value.String()
 
 		// Set ENV variables
 		os.Setenv("GHMT_TARGET_ORGANIZATION", targetOrganization)
@@ -37,6 +38,7 @@ var byReposCmd = &cobra.Command{
 		os.Setenv("GHMT_MAPPING_FILE", mappingFile)
 		os.Setenv("GHMT_SOURCE_HOSTNAME", ghHostname)
 		os.Setenv("GHMT_REPO_FILE", repoFile)
+		os.Setenv("GHMT_SKIP_TEAMS", skipTeams)
 
 		// Bind ENV variables in Viper
 		viper.BindEnv("TARGET_ORGANIZATION")
@@ -72,6 +74,8 @@ func init() {
 	byReposCmd.MarkFlagRequired("from-file")
 
 	byReposCmd.Flags().StringP("mapping-file", "m", "", "Mapping file path to use for mapping teams members handles")
+
+	byReposCmd.Flags().BoolP("skip-teams", "k", false, "Skips adding members and repos to teams that already exist to save on API requests (default \"false\")")
 
 	byReposCmd.Flags().StringP("source-hostname", "u", os.Getenv("SOURCE_HOST"), "GitHub Enterprise source hostname url (optional) Ex. https://github.example.com")
 }


### PR DESCRIPTION
This pull request includes updates to the `byReposCmd` command in the `cmd/byRepos.go` file to introduce a new flag for skipping teams. The most important changes involve adding the `skip-teams` flag and ensuring it is properly handled within the command.

This flag is already being leveraged at the create Team api level as an environmental variable to decide whether to skip teams or not.

New flag and environment variable:

* [`cmd/byRepos.go`](diffhunk://#diff-a1c749754e49eeeb415a757710a4fb54b6b8107911afa0cb82662ea28dbc72a6R78-R79): Added a new flag `skip-teams` to the `byReposCmd` command, which allows users to skip adding members and repos to teams that already exist to save on API requests.
* [`cmd/byRepos.go`](diffhunk://#diff-a1c749754e49eeeb415a757710a4fb54b6b8107911afa0cb82662ea28dbc72a6R41): Set the `GHMT_SKIP_TEAMS` environment variable using the value of the `skip-teams` flag.
* [`cmd/byRepos.go`](diffhunk://#diff-a1c749754e49eeeb415a757710a4fb54b6b8107911afa0cb82662ea28dbc72a6R32): Retrieved the value of the `skip-teams` flag and assigned it to the `skipTeams` variable.