### PR TITLE
remove authenticated user if not part of membership

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -389,3 +389,27 @@ func GetRepositoryTeams(owner string, repo string) ([]*github.Team, error) {
 
 	return teams, nil
 }
+
+func GetAuthenticatedUser() (*github.User, error) {
+	client := newGHRestClient(viper.GetString("TARGET_TOKEN"))
+	ctx := context.Background()
+
+	// Get authenticated user
+	user, _, err := client.Users.Get(ctx, "")
+
+	if err != nil {
+		return nil, err
+	}
+	return user, nil
+}
+
+func RemoveTeamMember(slug string, member string) error {
+	client := newGHRestClient(viper.GetString("TARGET_TOKEN"))
+	ctx := context.WithValue(context.Background(), github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true)
+
+	_, err := client.Teams.RemoveTeamMembershipBySlug(ctx, viper.Get("TARGET_ORGANIZATION").(string), slug, member)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -103,7 +103,12 @@ func SyncTeamsByRepo() {
 		if os.Getenv("GHMT_MAPPING_FILE") != "" {
 			team = mapMembers(team)
 		}
+
+		//update Spinner text with the team name
+		createTeamsSpinnerSuccess.UpdateText("Creating team in target organization: " + team.Name)
+
 		team.CreateTeam()
+
 	}
 	createTeamsSpinnerSuccess.Success()
 }


### PR DESCRIPTION
This pull request introduces adding functions to get the authenticated user and remove a team member, and updating the team creation logic to ensure the authenticated user is correctly managed.

The authenticated user that creates the team gets automatically added to the team. However, that is most likely not the desired outcome. This functionality removes the authenticated user from the team if they are not part of the source team members.

New functionalities:

* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R392-R415): Added `GetAuthenticatedUser` function to retrieve the authenticated user and `RemoveTeamMember` function to remove a team member by slug.

Enhancements to team synchronization:

* [`internal/team/team.go`](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R128-R149): Updated `CreateTeam` method to retrieve the authenticated user, check if they are part of the team members, and remove them if they are not.
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR106-R111): Improved `SyncTeamsByRepo` function to update the spinner text with the team name during the team creation process.