### PR TITLE
fix rate limit, adds de-duplication of teams

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -379,7 +379,7 @@ func GetTeamId(TeamName string) (int64, error) {
 
 func GetRepositoryTeams(owner string, repo string) ([]*github.Team, error) {
 	client := newGHRestClient(viper.GetString("SOURCE_TOKEN"))
-	ctx := context.Background()
+	ctx := context.WithValue(context.Background(), github.SleepUntilPrimaryRateLimitResetWhenRateLimited, true)
 
 	// Get teams for the repository
 	teams, _, err := client.Repositories.ListTeams(ctx, owner, repo, nil)

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -84,6 +84,7 @@ func SyncTeamsByRepo() {
 	teamsSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Fetching teams from repository list...")
 	repos, err := repository.ParseRepositoryFile(os.Getenv("GHMT_REPO_FILE"))
 	teams := []team.Team{}
+	teamMap := make(map[string]bool) // Map to track added teams
 
 	if err != nil {
 		log.Println("error while reading repository file - ", err)
@@ -91,8 +92,16 @@ func SyncTeamsByRepo() {
 		return
 	}
 	for _, repo := range repos {
-		// get all teams that have access to the repository and add them to the teams slice
-		teams = append(teams, team.GetRepositoryTeams(repo)...)
+		// get all teams that have access to the repository
+		repoTeams := team.GetRepositoryTeams(repo)
+		for _, t := range repoTeams {
+			// Check if the team is already in the map
+			if _, exists := teamMap[t.Id]; !exists {
+				// If the team is not in the map, add it to the map and the teams slice
+				teamMap[t.Id] = true
+				teams = append(teams, t)
+			}
+		}
 	}
 	teamsSpinnerSuccess.Success()
 


### PR DESCRIPTION
This pull request includes changes to improve the handling of GitHub API rate limits and optimize the process of fetching repository teams by avoiding duplicate entries.

### Rate Limit Handling:
* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834L382-R382): Updated the context in `GetRepositoryTeams` to include a value that ensures the client sleeps until the primary rate limit is reset when rate limited.

### Team Synchronization Optimization:
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR87-R104): Introduced a map to track added teams in `SyncTeamsByRepo` to avoid adding duplicate teams to the list.