### PR TITLE
Adds ratelimit support for GraphQL queries

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -43,7 +43,9 @@ func (c *RateLimitAwareGraphQLClient) Query(ctx context.Context, q interface{}, 
 			return nil
 		} else {
 			// Sleep until rate limit resets
+			log.Println("Rate limit exceeded, sleeping until reset at:", rateLimitQuery.RateLimit.ResetAt.Time)
 			time.Sleep(time.Until(rateLimitQuery.RateLimit.ResetAt.Time))
+
 		}
 	}
 }

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
+	"time"
 
 	"github.com/gofri/go-github-ratelimit/github_ratelimit"
 	"github.com/google/go-github/v62/github"
@@ -12,9 +14,44 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func newGHGraphqlClient(token string) *githubv4.Client {
+type RateLimitAwareGraphQLClient struct {
+	client *githubv4.Client
+}
+
+func (c *RateLimitAwareGraphQLClient) Query(ctx context.Context, q interface{}, variables map[string]interface{}) error {
+	var rateLimitQuery struct {
+		RateLimit struct {
+			Remaining int
+			ResetAt   githubv4.DateTime
+		}
+	}
+
+	for {
+		// Check the current rate limit
+		if err := c.client.Query(ctx, &rateLimitQuery, nil); err != nil {
+			return err
+		}
+
+		log.Println("Rate limit remaining:", rateLimitQuery.RateLimit.Remaining)
+
+		if rateLimitQuery.RateLimit.Remaining > 0 {
+			// Proceed with the actual query
+			err := c.client.Query(ctx, q, variables)
+			if err != nil {
+				return err
+			}
+			return nil
+		} else {
+			// Sleep until rate limit resets
+			time.Sleep(time.Until(rateLimitQuery.RateLimit.ResetAt.Time))
+		}
+	}
+}
+
+func newGHGraphqlClient(token string) *RateLimitAwareGraphQLClient {
 	hostname := viper.GetString("SOURCE_HOSTNAME")
-	var client *githubv4.Client
+	var baseClient *githubv4.Client
+
 	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	httpClient := oauth2.NewClient(context.Background(), src)
 	rateLimiter, err := github_ratelimit.NewRateLimitWaiterClient(httpClient.Transport)
@@ -22,16 +59,20 @@ func newGHGraphqlClient(token string) *githubv4.Client {
 	if err != nil {
 		panic(err)
 	}
-	client = githubv4.NewClient(rateLimiter)
 
 	// Trim any trailing slashes from the hostname
 	hostname = strings.TrimSuffix(hostname, "/")
 
 	// If hostname is received, create a new client with the hostname
 	if hostname != "" {
-		client = githubv4.NewEnterpriseClient(hostname+"/api/graphql", rateLimiter)
+		baseClient = githubv4.NewEnterpriseClient(hostname+"/api/graphql", rateLimiter)
+	} else {
+		baseClient = githubv4.NewClient(rateLimiter)
 	}
-	return client
+
+	return &RateLimitAwareGraphQLClient{
+		client: baseClient,
+	}
 }
 
 func newGHRestClient(token string) *github.Client {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/mona-actions/gh-migrate-teams/internal/repository"
@@ -85,6 +86,7 @@ func SyncTeamsByRepo() {
 	repos, err := repository.ParseRepositoryFile(os.Getenv("GHMT_REPO_FILE"))
 	teams := []team.Team{}
 	teamMap := make(map[string]bool) // Map to track added teams
+	totalMembers := 0
 
 	if err != nil {
 		log.Println("error while reading repository file - ", err)
@@ -100,9 +102,13 @@ func SyncTeamsByRepo() {
 				// If the team is not in the map, add it to the map and the teams slice
 				teamMap[t.Id] = true
 				teams = append(teams, t)
+				totalMembers += len(t.Members)
 			}
 		}
 	}
+	// Print out how many teams were found:
+	teamsSpinnerSuccess.UpdateText("Fetched a total of " + strconv.Itoa(len(teams)) + " teams with total of " + strconv.Itoa(totalMembers) + " members from the repository list")
+
 	teamsSpinnerSuccess.Success()
 
 	// Create teams in target organization


### PR DESCRIPTION
This pull request introduces a rate limit handling in the GraphQL client and adds functionality to track and report the total number of team members during synchronization. The most important changes include the creation of a new rate limit-aware GraphQL client

### Enhancements to rate limit handling:

* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834L15-L34): Introduced a new `RateLimitAwareGraphQLClient` type to handle rate limits by checking the current rate limit before making a query and sleeping until the limit resets if exceeded.

### Logging improvements:

* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R6-R8): Added logging for rate limit status and sleep duration when the rate limit is exceeded.
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR105-R111): Added logging to print out the total number of teams and members fetched from the repository list.

### Other changes:

* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR89): Added a counter to track the total number of members in the fetched teams.
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR7): Imported the `strconv` package to convert integers to strings for logging purposes.