### PR TITLE
Support for team-renaming for byRepos subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@
 gh extension install mona-actions/gh-migrate-teams
 ```
 
+>[!NOTE]
+> If setting any environmental variables through this CLI extension, make sure to add the `GHMT` prefix. For example, `GHMT_TOKEN` instead of `TOKEN`.
+
 ## Usage: Export
 
 Export team membership, team repository access, and repository collaborator access to CSV files.
@@ -42,6 +45,25 @@ Flags:
   -t, --target-organization string   Target Organization to sync teams from
   -b, --target-token string          Target Organization GitHub token. Scopes: admin:org
   -z, --user-sync string             User sync mode. One of: all, disable (default "none") (default "all")
+```
+
+### Sync by Repository List
+
+You can also sync teams by providing a list of repositories to sync. This is useful when you want to sync a subset of repositories from the source organization to the target organization.
+
+```bash
+Usage:
+  migrate-teams sync byRepos [flags]
+
+Flags:
+  -f, --from-file string             File path to use for repository list (default "repositories.txt")
+  -h, --help                         help for byRepos
+  -m, --mapping-file string          Mapping file path to use for mapping teams members handles
+  -k, --skip-teams                   Skips adding members and repos to teams that already exist to save on API requests (default "false")
+  -u, --source-hostname string       GitHub Enterprise source hostname url (optional) Ex. https://github.example.com
+  -a, --source-token string          Source Organization GitHub token. Scopes: read:org, read:user, user:email
+  -t, --target-organization string   Target Organization to sync teams from
+  -b, --target-token string          Target Organization GitHub token. Scopes: admin:org
 ```
 
 ### Mapping File Example

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -25,8 +25,9 @@ func newHTTPClient() *http.Client {
 	installationId := viper.GetInt64("TARGET_INSTALLATION_ID")
 
 	// check that Target token or GitHub App values are set
-	if token != "" && (appId == "" || len(privateKey) == 0 || installationId == 0) {
-		log.Fatalf("Please provide a target token or a target GitHub App ID and private key")
+	if token == "" && (appId == "" || len(privateKey) == 0 || installationId == 0) {
+		log.Fatalf(
+			"Please provide a target token or a target GitHub App ID and private key \n Received: length of token: %v, length of private key: %v, installation ID: %v", len(token), len(privateKey), installationId)
 	}
 
 	if appId != "" && len(privateKey) != 0 && installationId != 0 {
@@ -48,12 +49,11 @@ func newHTTPClient() *http.Client {
 
 		return httpClient
 
-	} else {
-		// Personal access token authentication
-		token := viper.GetString("TARGET_TOKEN")
-		src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
-		return oauth2.NewClient(context.Background(), src)
 	}
+	// Personal access token authentication
+	src := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	return oauth2.NewClient(context.Background(), src)
+
 }
 
 type RateLimitAwareGraphQLClient struct {
@@ -109,6 +109,10 @@ func newGHGraphqlClient(token string) *RateLimitAwareGraphQLClient {
 
 	// If hostname is received, create a new client with the hostname
 	if hostname != "" {
+		hostname = strings.TrimSuffix(hostname, "/")
+		if !strings.HasPrefix(hostname, "https://") {
+			hostname = "https://" + hostname
+		}
 		baseClient = githubv4.NewEnterpriseClient(hostname+"/api/graphql", rateLimiter)
 	} else {
 		baseClient = githubv4.NewClient(rateLimiter)
@@ -132,6 +136,7 @@ func newGHRestClient() *github.Client {
 
 func newSourceGHRestClient() *github.Client {
 	token := viper.GetString("SOURCE_TOKEN")
+	hostname := viper.GetString("SOURCE_HOSTNAME")
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
 	tc := oauth2.NewClient(ctx, ts)
@@ -139,6 +144,19 @@ func newSourceGHRestClient() *github.Client {
 
 	if err != nil {
 		panic(err)
+	}
+
+	if hostname != "" {
+		hostname = strings.TrimSuffix(hostname, "/")
+		if !strings.HasPrefix(hostname, "https://") {
+			hostname = "https://" + hostname
+		}
+		baseURL := fmt.Sprintf("%s/api/v3/", hostname)
+		client, err := github.NewClient(rateLimiter).WithEnterpriseURLs(baseURL, baseURL)
+		if err != nil {
+			panic(err)
+		}
+		return client
 	}
 
 	return github.NewClient(rateLimiter)

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -27,7 +27,7 @@ func newHTTPClient() *http.Client {
 	// check that Target token or GitHub App values are set
 	if token == "" && (appId == "" || len(privateKey) == 0 || installationId == 0) {
 		log.Fatalf(
-			"Please provide a target token or a target GitHub App ID and private key \n Received: length of token: %v, length of private key: %v, installation ID: %v", len(token), len(privateKey), installationId)
+			"Please provide a target token or a target GitHub App ID and private key.")
 	}
 
 	if appId != "" && len(privateKey) != 0 && installationId != 0 {

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -111,6 +111,7 @@ func SyncTeamsByRepo() {
 
 	if len(teams) == 0 {
 		teamsSpinnerSuccess.Fail()
+		log.Fatalf("No teams fetched from source. Check the values of org, repos, tokens to ensure they are correct. Check logs for more details.")
 		return
 	}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -109,6 +109,11 @@ func SyncTeamsByRepo() {
 	// Print out how many teams were found:
 	teamsSpinnerSuccess.UpdateText("Fetched a total of " + strconv.Itoa(len(teams)) + " teams with total of " + strconv.Itoa(totalMembers) + " members from the repository list")
 
+	if len(teams) == 0 {
+		teamsSpinnerSuccess.Fail()
+		return
+	}
+
 	teamsSpinnerSuccess.Success()
 
 	// Create teams in target organization
@@ -125,5 +130,6 @@ func SyncTeamsByRepo() {
 		team.CreateTeam()
 
 	}
+	createTeamsSpinnerSuccess.UpdateText("Team creation process completed")
 	createTeamsSpinnerSuccess.Success()
 }


### PR DESCRIPTION
This pull request includes several changes to the `byRepos` subcommand. Mainly it is based on two ENV files `GHMT_TEAM_MAPPING_FILE` and `GHMT_REPO_MAPPING_FILE`. If this two values are set, the idea is that if repos when migrated are being renamed as well as Teams need to be renamed from source and target, this mapping files can handle this scenario.

> [!NOTE]
> This is a very niche scenario that when migrating and there is an org consolidation. Therefore, teams and repo names may have collisions when migrating. Setting this up as ENV variables and using this as "toggles" as well. If set, mappings will run.

Mapping files are in the following format

```csv
source,target
<org>/<team-name>,<target-team-name>
```

```csv
source,target
<org>/<repo-name>,<target-repo-name>
```



Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R13): Added a note about the `GHMT` prefix for environmental variables and documented the new `sync byRepos` command for syncing teams by a list of repositories. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R11-R13) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R50-R68)

Code enhancements:

* [`internal/api/api.go`](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834L28-R30): Improved error handling for target token or GitHub App values, ensured hostname URLs are correctly formatted, and added support for custom hostnames in REST client creation. [[1]](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834L28-R30) [[2]](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834L51-R56) [[3]](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R112-R115) [[4]](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R139) [[5]](diffhunk://#diff-5b9b550fff634f1fd5596893d63ceeb6afa6a355427db919a644a21f097b7834R149-R161)
* [`internal/team/team.go`](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R4-R6): Added functionality to read repository and team mappings from CSV files and apply these mappings during the migration process. [[1]](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R4-R6) [[2]](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R84-R95) [[3]](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R109-R118) [[4]](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R212-R241) [[5]](diffhunk://#diff-550465d6e3fb4f4899011af28f7f57011e68e96a5ea0d5eb15a06facc72cf450R254-R275)
* [`pkg/sync/sync.go`](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR112-R117): Enhanced error handling and logging in the `SyncTeamsByRepo` function to ensure better feedback during the sync process. [[1]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR112-R117) [[2]](diffhunk://#diff-2e7c810166140fd7a58d6bdb610fef7e6de8f5f9ad2002659392878ecafd6befR134)