### PR TITLE
add PR template and release drafter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+<!--
+## Release Drafter
+
+This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:
+
+- `major` label will be a major version
+- `minor` or `enhancement` will bump it to a minor version
+- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
+-->
+
+## Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context.
+
+## Checklist
+
+<!-- - [ ] Issue linked if existing -->
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests
+
+## Additional Context
+
+Add any other context or screenshots about the pull request here.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,33 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER) 🚢'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'patch'
+      - 'bug'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,18 @@
+name: Release Drafter Update
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'README.md'
+      - '.github/**'
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to integrate and configure Release Drafter for versioning, along with updates to the pull request template and GitHub workflow. The most important changes include adding a new pull request template, configuring Release Drafter, and setting up a GitHub Actions workflow to update the release draft.

Integration of Release Drafter:

* [`.github/pull_request_template.md`](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R24): Updated to include instructions for using Release Drafter labels to indicate the type of change.
* [`.github/release-drafter.yml`](diffhunk://#diff-101bec72d0f1f84e7290d113531bbd8c6aa355cdc9f456df255544bc0a2da0eaR1-R33): Added configuration for Release Drafter, specifying templates for release names, tags, and categories for different types of changes.

Automation of release note generation:

* [`.github/workflows/release-drafter.yml`](diffhunk://#diff-6942706d71f70018c8f087d0a45e76d7192106920b2b3892cb86f70443ec2078R1-R18): Created a GitHub Actions workflow to automatically update the release draft on pushes to the main branch, excluding certain paths.