### PR TITLE
reduce rate limit log noise and spinner delay

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -74,7 +74,10 @@ func (c *RateLimitAwareGraphQLClient) Query(ctx context.Context, q interface{}, 
 			return err
 		}
 
-		log.Println("Rate limit remaining:", rateLimitQuery.RateLimit.Remaining)
+		// Only log when rate limit is getting low (under 100) or when we hit the limit
+		if rateLimitQuery.RateLimit.Remaining < 100 {
+			log.Println("Rate limit remaining:", rateLimitQuery.RateLimit.Remaining)
+		}
 
 		if rateLimitQuery.RateLimit.Remaining > 0 {
 			// Proceed with the actual query

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -148,7 +148,7 @@ func SyncTeamsByRepo() {
 	teamsSpinnerSuccess.Success()
 
 	// Create teams in target organization
-	createTeamsSpinnerSuccess, _ := pterm.DefaultSpinner.Start("Creating teams in target organization...")
+	createTeamsSpinnerSuccess, _ := pterm.DefaultSpinner.WithDelay(1 * time.Minute).Start("Creating teams in target organization...")
 	for _, team := range teams {
 		// Map members
 		if os.Getenv("GHMT_MAPPING_FILE") != "" {


### PR DESCRIPTION

<!--
## Release Drafter

This repository uses [Release Drafter](https://github.com/release-drafter/release-drafter) for versioning. Please add one of the following labels to your pull request to indicate the type of change:

- `major` label will be a major version
- `minor` or `enhancement` will bump it to a minor version
- `patch` or `bug` will bump it to a patch version (this is the default if no label is applied)
-->

## Description

This pull request introduces improvements to logging and user feedback mechanisms in the codebase. The most notable changes are rate limit logging is only logged when the rate limit remaining is low (less than 100)
## Checklist

<!-- - [ ] Issue linked if existing -->
- [ ] I have commented my code, particularly in hard-to-understand areas - N\A
- [ ] I have made corresponding changes to the documentation - N\A
- [ ] I have added tests - N\A

## Additional Context

**Logging and Monitoring Enhancements:**

* Added a conditional log statement in `internal/api/api.go` to only log the remaining rate limit when it drops below 100, reducing unnecessary log noise and helping to monitor potential throttling more effectively.

**User Interface Improvements:**

* Updated the spinner in `pkg/sync/sync.go` during team creation to include a delay of one minute, providing clearer feedback to users during longer operations.